### PR TITLE
Correct Twitter Bootstrap path.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,8 +10,8 @@
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     <!-- Twitter Bootstrap -->
-    <script src="./bootstrap/dist/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="./bootstrap/dist/css/bootstrap.min.css">
+    <script src="/bootstrap/dist/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="/bootstrap/dist/css/bootstrap.min.css">
     <!-- syntax highlighting CSS -->
     <link rel="stylesheet" href="/css/syntax.css">
     <!-- Custom CSS -->


### PR DESCRIPTION
不好意思，剛剛修改的 Twitter Bootstrap 引用的路徑有錯，首頁以外的頁面版面應該全走樣了。
