### PR TITLE
Translate 'ca-certificates-utils 20170307-1 upgrade requires manual intervention'

### DIFF
--- a/_posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown
+++ b/_posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown
@@ -1,15 +1,19 @@
 ---
 layout: post
-title:  "TRANSLATE_THIS_TITLE: ca-certificates-utils 20170307-1 upgrade requires manual intervention"
+title:  "升級到 ca-certificates-utils 20170307-1 版需要手動處理"
 date:   2017-03-15T21:27:54+00:00
-author: "TRANSLATOR_NAME_HERE"
+author: "Huei-Horng Yo"
 ---
 
 **原文：**[ca-certificates-utils 20170307-1 upgrade requires manual intervention](https://www.archlinux.org/news/ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention/)
 
-<p>The upgrade to <strong>ca-certificates-utils 20170307-1</strong> requires manual intervention because a symlink which used to be generated post-install has been moved into the package proper.</p>
-<p>As deleting the symlink may leave you unable to download packages, perform this upgrade in three steps:</p>
-<pre><code># pacman -Syuw                           # download packages
+由於在 `ca-certificates-utils` 裡頭有個符號連結檔案之前是在 post-install 階段生成的，但是現在已經直接移入套件內，所以升級到 `20170307-1` 版時，需要您手動處理。
+
+如果直接把這個符號連結檔案刪除，可能會導致無法正常下載套件，所以請依照以下三個步驟操作此項升級：
+
+```
+# pacman -Syuw                           # download packages
 # rm /etc/ssl/certs/ca-certificates.crt  # remove conflicting file
 # pacman -Su                             # perform upgrade
-</code></pre>
+```
+

--- a/_posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown
+++ b/_posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown
@@ -1,0 +1,15 @@
+---
+layout: post
+title:  "TRANSLATE_THIS_TITLE: ca-certificates-utils 20170307-1 upgrade requires manual intervention"
+date:   2017-03-15T21:27:54+00:00
+author: "TRANSLATOR_NAME_HERE"
+---
+
+**原文：**[ca-certificates-utils 20170307-1 upgrade requires manual intervention](https://www.archlinux.org/news/ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention/)
+
+<p>The upgrade to <strong>ca-certificates-utils 20170307-1</strong> requires manual intervention because a symlink which used to be generated post-install has been moved into the package proper.</p>
+<p>As deleting the symlink may leave you unable to download packages, perform this upgrade in three steps:</p>
+<pre><code># pacman -Syuw                           # download packages
+# rm /etc/ssl/certs/ca-certificates.crt  # remove conflicting file
+# pacman -Su                             # perform upgrade
+</code></pre>


### PR DESCRIPTION
Please help us to translate 'ca-certificates-utils 20170307-1 upgrade requires manual intervention':

1. `git pull`
2. `git checkout news/20170315-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention`
3. edit `_posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown`
4. `git add _posts/2017-03-15-ca-certificates-utils-20170307-1-upgrade-requires-manual-intervention.markdown`
5. `git commit`
6. `git push`

Thanks! :bow:
