### PR TITLE
WIP: Translate 'Deprecation of ABS tool and rsync endpoint'

### DIFF
--- a/_posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown
+++ b/_posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown
@@ -1,0 +1,21 @@
+---
+layout: post
+title:  "TRANSLATE_THIS_TITLE: Deprecation of ABS tool and rsync endpoint"
+date:   2017-05-15T10:55:50+00:00
+author: "TRANSLATOR_NAME_HERE"
+---
+
+**原文：**[Deprecation of ABS tool and rsync endpoint](https://www.archlinux.org/news/deprecation-of-abs/)
+
+<p>Due to high maintenance cost of scripts related to the Arch Build
+System, we have decided to deprecate the <code>abs</code> tool and thus rsync
+as a way of obtaining PKGBUILDs.</p>
+<p>The <code>asp</code> tool, available in [extra], provides similar functionality to
+<code>abs</code>.  <code>asp export pkgname</code> can be used as direct alternative; more
+information about its usage can be found in <a href="https://github.com/falconindy/asp/blob/master/man/asp.1.txt">the documentation</a>.
+Additionally Subversion sparse checkouts, as described <a href="https://www.archlinux.org/svn/">here</a>, can
+be used to achieve a similar effect.  For fetching all PKGBUILDs, the
+best way is cloning the <a href="https://git.archlinux.org/svntogit/">svntogit</a> mirrors.</p>
+<p>While the <code>extra/abs</code> package has been already dropped, the rsync
+endpoint (rsync://rsync.archlinux.org/abs) will be disabled by the end
+of the month.</p>

--- a/_posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown
+++ b/_posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown
@@ -1,21 +1,14 @@
 ---
 layout: post
-title:  "TRANSLATE_THIS_TITLE: Deprecation of ABS tool and rsync endpoint"
+title:  "棄用 ABS 工具與 rsync 端點"
 date:   2017-05-15T10:55:50+00:00
-author: "TRANSLATOR_NAME_HERE"
+author: "Huei-Horng Yo"
 ---
 
 **原文：**[Deprecation of ABS tool and rsync endpoint](https://www.archlinux.org/news/deprecation-of-abs/)
 
-<p>Due to high maintenance cost of scripts related to the Arch Build
-System, we have decided to deprecate the <code>abs</code> tool and thus rsync
-as a way of obtaining PKGBUILDs.</p>
-<p>The <code>asp</code> tool, available in [extra], provides similar functionality to
-<code>abs</code>.  <code>asp export pkgname</code> can be used as direct alternative; more
-information about its usage can be found in <a href="https://github.com/falconindy/asp/blob/master/man/asp.1.txt">the documentation</a>.
-Additionally Subversion sparse checkouts, as described <a href="https://www.archlinux.org/svn/">here</a>, can
-be used to achieve a similar effect.  For fetching all PKGBUILDs, the
-best way is cloning the <a href="https://git.archlinux.org/svntogit/">svntogit</a> mirrors.</p>
-<p>While the <code>extra/abs</code> package has been already dropped, the rsync
-endpoint (rsync://rsync.archlinux.org/abs) will be disabled by the end
-of the month.</p>
+因為維護與 Arch Build System 相關腳本程式 (scripts) 的成本過高，我們決定棄用 `abs` 工具，以及不再提供 rsync 此一管道來獲取 PKGBUILDs。
+
+在 [extra] 套件庫裡的 `asp` 工具提供了近似 `abs` 的功能。使用 `asp export pkgname` 指令即可直接替代；更多有關 `asp` 的用法資訊可以在[文件](https://github.com/falconindy/asp/blob/master/man/asp.1.txt)處找到。除此之外，使用 Subversion 個別提取（[參見這裡](https://www.archlinux.org/svn/)）也可達到相似的作用。如果要獲取全部的 PKGBUILDs，最好的方法是複製 [svntogit](https://git.archlinux.org/svntogit/) 的鏡像來源。
+
+目前 `extra/abs` 套件已被下架，而 rsync 端點 (rsync://rsync.archlinux.org/abs) 亦將於本月底關閉。


### PR DESCRIPTION
Please help us to translate 'Deprecation of ABS tool and rsync endpoint':

1. `git pull`
2. `git checkout news/20170515-deprecation-of-abs-tool-and-rsync-endpoint`
3. edit `_posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown`
4. `git add _posts/2017-05-15-deprecation-of-abs-tool-and-rsync-endpoint.markdown`
5. `git commit`
6. `git push`

Thanks! :bow:
