### PR TITLE
ci(action): no need to trigger on PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: jekyll-cd
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
To avoid the following error:

remote: Permission to linux-taiwan/arch.linux.org.tw.git denied to github-actions[bot].